### PR TITLE
Export lowercased cat urls based on Shopware config

### DIFF
--- a/FinSearchAPI/BusinessLogic/Models/FindologicArticleModel.php
+++ b/FinSearchAPI/BusinessLogic/Models/FindologicArticleModel.php
@@ -386,6 +386,11 @@ class FindologicArticleModel
             
             $catPath = $this->seoRouter->sCategoryPath($category->getId());
             $tempPath = '/'.implode('/', $catPath);
+
+            if (Shopware()->Config()->get('routerToLower')) {
+                $tempPath = strtolower($tempPath);
+            }
+
             $catUrlArray[] = $this->seoRouter->sCleanupPath($tempPath);
             $exportCat = StaticHelper::buildCategoryName($category->getId(), false);
 


### PR DESCRIPTION
ATM we do not export lowercased `cat_url`s if the config in the Shopware backend under `Configuration -> Basic Settings -> Frontend -> SEO / router settings -> Only use lower case letters in URLs` is set. This is necessary as our `sRewriteTable` aka `seoRouter` doesn't take care of this.

The config can be find via the following key `routerToLower`.

`Shopware()->Config()->get('routerToLower')`