### PR TITLE
Replace brackets from image urls

### DIFF
--- a/FinSearchAPI/BusinessLogic/Models/FindologicArticleModel.php
+++ b/FinSearchAPI/BusinessLogic/Models/FindologicArticleModel.php
@@ -335,8 +335,13 @@ class FindologicArticleModel
                 }
 
                 if (count($imageDetails) > 0) {
-                    $imagePath = $mediaService->getUrl($imageDefault);
-                    $imagePathThumb = $mediaService->getUrl(array_values($imageDetails)[0]);
+                    $replacements = array(
+                        '[' => '%5B',
+                        ']' => '%5D'
+                    );
+
+                    $imagePath = strtr($mediaService->getUrl($imageDefault), $replacements);
+                    $imagePathThumb = strtr($mediaService->getUrl(array_values($imageDetails)[0]), $replacements);
                     if ($imagePathThumb != '') {
                         $xmlImagePath = new \FINDOLOGIC\Export\Data\Image($imagePath, \FINDOLOGIC\Export\Data\Image::TYPE_DEFAULT);
                         $imagesArray[] = $xmlImagePath;
@@ -383,7 +388,7 @@ class FindologicArticleModel
             if (!$category->isChildOf($this->baseCategory)){
                 continue;
             }
-            
+
             $catPath = $this->seoRouter->sCategoryPath($category->getId());
             $tempPath = '/'.implode('/', $catPath);
             $catUrlArray[] = $this->seoRouter->sCleanupPath($tempPath);


### PR DESCRIPTION
This replaces brackets in image urls which might appear on some shopware instances. URLs like `https://www.xyz.de/media/image/3a/83/55/88780_image1[1].jpg` breaks the XSD Schema requirements. This edgecase is not handled by the libflexport library at the moment. Issue was created [here](https://github.com/findologic/libflexport/issues/66). Still images can have non URL encoded links which will be fixed by this PR.